### PR TITLE
Re-scale image after flat field correction

### DIFF
--- a/mermake/deconvolver.py
+++ b/mermake/deconvolver.py
@@ -104,6 +104,8 @@ class Deconvolver:
 		psf_ffts = cycle(self.psf_fft) if len(self.psf_fft) == 1 else iter(self.psf_fft)
 		tiles = self.tiled(image)
 		flats = cycle([(None,None,None)]) if flat_field is None else self.tiled(flat_field[np.newaxis])
+		if flat_field is not None:
+			med = cp.median(flat_field)
 	
 		z = image.shape[0]
 		# the big loop
@@ -118,6 +120,7 @@ class Deconvolver:
 			# flat field correction
 			if flat_field is not None:
 				cp.divide(tile_pad[zpad:-zpad], flat, out=tile_pad[zpad:-zpad])
+				tile_pad[zpad:-zpad] *= med
 			
 			# the fft convolution and deconvolution
 			tile_fft[:] = xp.fft.fftn(tile_pad)


### PR DESCRIPTION
In the old scripts, the image was re-scaled after flat field correction to restore the original range of brightness values. The threshold=3600 parameter is dependent on this re-scaling.